### PR TITLE
This fixes a number of problems around the pcap-fifo handling

### DIFF
--- a/sratunnel/output.c
+++ b/sratunnel/output.c
@@ -59,7 +59,12 @@ static bool out_nmsg_mod_checked = false;
 void
 out_close(void)
 {
-	out_flush();
+        // Try to flush for up to 10 seconds
+        int n = 0;
+        do {
+	        out_flush();
+                usleep(10000);
+        } while (out_buf_len > 0 && n++ < 1000);
 
 	if (out_pcap_dumper != NULL) {
 		pcap_dump_close(out_pcap_dumper);

--- a/sratunnel/output.c
+++ b/sratunnel/output.c
@@ -98,7 +98,8 @@ out_flush(void)
 			    && errno != EINTR) {
 				axa_error_msg("write(%s): %s",
 					      out_addr, strerror(errno));
-				stop(EX_IOERR);
+                                // Can't call stop as it recurses....
+				exit(EX_IOERR);
 			}
 		} else {
 			out_buf_base += wlen;
@@ -590,10 +591,10 @@ out_ip_pcap_file(const uint8_t *pkt, size_t caplen, size_t len,
 		return;
 	}
 
-	if (caplen + sizeof(sf_hdr) > sizeof(out_buf) - out_buf_len
+	if (caplen + sizeof(sf_hdr) + out_buf_len > sizeof(out_buf) / 2
 	    || out_buf_base != 0) {
 		out_flush();
-		if (caplen > sizeof(out_buf) - sizeof(sf_hdr) - out_buf_len) {
+		if (caplen + sizeof(sf_hdr) + out_buf_len > sizeof(out_buf)) {
 			out_error("forwarding output stalled; dropping");
 			return;
 		}


### PR DESCRIPTION
The underlying issue is that writing to a fifo typically does not write the full amount of data. The code in `out_flush` tries to handle this, but gets it wrong. In particular, the existing code tends to go into a stack overflow after writing the first block of data to the fifo. This causes a memory overwrite, and then the file number used for subsequent writes is invalid, and so it returns EBADF. The is caught, adn the code then tries to shut down cleanly -- which calls `out_close` which calls `out_flush` which fails to write (with EBADF) and no we are doomed.

Also, the `out_close` function assumed that `out_flush` would always flush *all* the buffered data -- and it doesn't.

This PR fixes those issues.